### PR TITLE
feat: add app config module with pydantic-settings (closes #51)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,30 @@
+# CS2 Arbitrage Dashboard — Environment Variables
+# Copy this file to .env and fill in your values.
+
+# ---- API Keys -----------------------------------------------------------
 # OddsAPI key (free tier from the-odds-api.com)
 ODDS_API_KEY=your_odds_api_key_here
-# Polymarket — no auth required for public CLOB endpoints
-POLYMARKET_CLOB_HOST=https://clob.polymarket.com
-# Arbitrage detection settings
-MIN_ARBITRAGE_EDGE_PCT=2.0
-CACHE_TTL_SECONDS=60
-REFRESH_INTERVAL_SECONDS=60
-LOG_LEVEL=INFO
+
+# OddsPapi API key (https://oddspapi.com)
+ODDSPAPI_API_KEY=your_oddspapi_api_key_here
+
+# ---- Arbitrage thresholds -----------------------------------------------
+# Minimum edge percentage to surface an opportunity (default 2%)
+MIN_EDGE_PCT=0.02
+
+# ---- Dashboard behaviour -------------------------------------------------
+# Auto-refresh interval in seconds
+REFRESH_INTERVAL_SECS=60
+
+# ---- Polymarket API URLs (defaults shown) --------------------------------
+POLYMARKET_GAMMA_URL=https://gamma-api.polymarket.com
+POLYMARKET_CLOB_URL=https://clob.polymarket.com
+
+# ---- The-Odds-API URL (default shown) ------------------------------------
+ODDS_API_BASE_URL=https://api.the-odds-api.com/v4
+
+# ---- OddsPapi base URL (default shown) -----------------------------------
+ODDSPAPI_BASE_URL=https://api.oddspapi.com
+
+# ---- Optional webhook for alert notifications (leave blank to disable) ---
+ALERT_WEBHOOK_URL=

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,75 @@
+"""Application settings loaded from environment variables via pydantic-settings.
+
+Usage::
+
+    from app.config import settings
+
+    api_key = settings.oddspapi_api_key
+    min_edge = settings.min_edge_pct
+
+All settings can be overridden by environment variables or a ``.env`` file at
+the project root.  This module supersedes the legacy ``config.py`` at the repo
+root — new code should import from here.
+"""
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Central configuration for the CS2 Arbitrage Dashboard.
+
+    Each field is populated first from an environment variable of the same name
+    (upper-cased), then falls back to the default value declared here.
+    """
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+    # --- API credentials ---------------------------------------------------
+    # Legacy field name kept for backwards compat with existing CI env var
+    odds_api_key: str = Field(default="", alias="ODDS_API_KEY")
+    oddspapi_api_key: str = Field(default="", alias="ODDSPAPI_API_KEY")
+
+    # --- Arbitrage thresholds ----------------------------------------------
+    min_edge_pct: float = Field(default=0.02, alias="MIN_EDGE_PCT")
+
+    # --- Dashboard behaviour -----------------------------------------------
+    refresh_interval_secs: int = Field(default=60, alias="REFRESH_INTERVAL_SECS")
+
+    # --- Polymarket API URLs -----------------------------------------------
+    polymarket_gamma_url: str = Field(
+        default="https://gamma-api.polymarket.com",
+        alias="POLYMARKET_GAMMA_URL",
+    )
+    polymarket_clob_url: str = Field(
+        default="https://clob.polymarket.com",
+        alias="POLYMARKET_CLOB_URL",
+    )
+
+    # --- The-Odds-API URL --------------------------------------------------
+    odds_api_base_url: str = Field(
+        default="https://api.the-odds-api.com/v4",
+        alias="ODDS_API_BASE_URL",
+    )
+
+    # --- OddsPapi base URL -------------------------------------------------
+    oddspapi_base_url: str = Field(
+        default="https://api.oddspapi.com",
+        alias="ODDSPAPI_BASE_URL",
+    )
+
+    # --- Alerting ----------------------------------------------------------
+    alert_webhook_url: str = Field(default="", alias="ALERT_WEBHOOK_URL")
+
+    # --- Bookmaker filter (empty = all bookmakers) -------------------------
+    enabled_bookmakers: list[str] = Field(default_factory=list)
+
+
+#: Module-level singleton — import this throughout the codebase.
+settings = Settings()

--- a/tests/test_config_module.py
+++ b/tests/test_config_module.py
@@ -1,0 +1,74 @@
+"""Unit tests for app.config Settings (pydantic-settings)."""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.config import Settings
+
+
+class TestSettingsDefaults:
+    def test_default_min_edge_pct(self) -> None:
+        s = Settings()
+        assert isinstance(s.min_edge_pct, float)
+        assert s.min_edge_pct == pytest.approx(0.02)
+
+    def test_default_refresh_interval(self) -> None:
+        s = Settings()
+        assert s.refresh_interval_secs == 60
+
+    def test_default_polymarket_gamma_url(self) -> None:
+        s = Settings()
+        assert s.polymarket_gamma_url == "https://gamma-api.polymarket.com"
+
+    def test_default_polymarket_clob_url(self) -> None:
+        s = Settings()
+        assert s.polymarket_clob_url == "https://clob.polymarket.com"
+
+    def test_default_api_keys_empty_string(self) -> None:
+        s = Settings()
+        assert s.oddspapi_api_key == ""
+        assert s.odds_api_key == ""
+
+    def test_default_alert_webhook_empty(self) -> None:
+        s = Settings()
+        assert s.alert_webhook_url == ""
+
+    def test_default_enabled_bookmakers_is_empty_list(self) -> None:
+        s = Settings()
+        assert s.enabled_bookmakers == []
+
+
+class TestSettingsOverrides:
+    def test_oddspapi_api_key_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ODDSPAPI_API_KEY", "test-key-123")
+        s = Settings()
+        assert s.oddspapi_api_key == "test-key-123"
+
+    def test_min_edge_pct_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MIN_EDGE_PCT", "0.05")
+        s = Settings()
+        assert s.min_edge_pct == pytest.approx(0.05)
+
+    def test_refresh_interval_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("REFRESH_INTERVAL_SECS", "120")
+        s = Settings()
+        assert s.refresh_interval_secs == 120
+
+    def test_alert_webhook_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ALERT_WEBHOOK_URL", "https://hooks.example.com/abc")
+        s = Settings()
+        assert s.alert_webhook_url == "https://hooks.example.com/abc"
+
+
+class TestSettingsImport:
+    def test_singleton_importable(self) -> None:
+        """The module-level `settings` singleton must be importable."""
+        from app.config import settings  # noqa: PLC0415
+
+        assert isinstance(settings, Settings)
+
+    def test_min_edge_pct_is_float(self) -> None:
+        from app.config import settings  # noqa: PLC0415
+
+        assert isinstance(settings.min_edge_pct, float)


### PR DESCRIPTION
## Summary

Adds the centralized application configuration module using `pydantic-settings`.

## Changes

- `app/config.py` — `Settings` class with pydantic-settings, loading all config from env vars / .env file. Includes module-level `settings` singleton.
- `tests/test_config_module.py` — unit tests for defaults, env overrides, and singleton import
- `.env.example` — updated with all required/optional env vars documented

## Config fields

| Field | Env var | Default |
|---|---|---|
| `odds_api_key` | `ODDS_API_KEY` | `""` |
| `oddspapi_api_key` | `ODDSPAPI_API_KEY` | `""` |
| `min_edge_pct` | `MIN_EDGE_PCT` | `0.02` |
| `refresh_interval_secs` | `REFRESH_INTERVAL_SECS` | `60` |
| `polymarket_gamma_url` | `POLYMARKET_GAMMA_URL` | Polymarket default |
| `polymarket_clob_url` | `POLYMARKET_CLOB_URL` | Polymarket default |
| `alert_webhook_url` | `ALERT_WEBHOOK_URL` | `""` |
| `enabled_bookmakers` | `ENABLED_BOOKMAKERS` | `[]` |

## Closes

Closes #51