### PR TITLE
feat: add Gamma API cursor pagination to get_cs2_markets (closes #76)

### DIFF
--- a/src/clients/polymarket_client.py
+++ b/src/clients/polymarket_client.py
@@ -53,12 +53,13 @@ class PolymarketClient:
         reraise=True,
     )
     def get_cs2_markets(self) -> list[dict[str, Any]]:
-        """Fetch active CS2 markets from the Gamma API.
+        """Fetch active CS2 markets from the Gamma API with cursor-based pagination.
 
-        Calls ``GET /markets?tag=cs2&active=true``.
+        Calls ``GET /markets?tag=cs2&active=true`` and follows ``next_cursor``
+        until all pages are exhausted.
 
         Returns:
-            List of market dicts, each containing at minimum:
+            Flat list of market dicts across all pages, each containing at minimum:
             - ``conditionId`` (str): used as *market_id* in CLOB calls.
             - ``question`` (str): human-readable market title.
             - ``active`` (bool): whether the market is currently live.
@@ -70,14 +71,27 @@ class PolymarketClient:
         """
         url = f"{self._gamma_url}/markets"
         params: dict[str, str] = {"tag": "cs2", "active": "true"}
-        logger.debug("GET %s params=%s", url, params)
-        resp = self._session.get(url, params=params, timeout=self._timeout)
-        resp.raise_for_status()
-        data: Any = resp.json()
-        # Gamma returns either a plain list or {"markets": [...]}
-        if isinstance(data, list):
-            return data  # type: ignore[return-value]
-        return data.get("markets", [])  # type: ignore[return-value]
+        markets: list[dict[str, Any]] = []
+
+        while True:
+            logger.debug("GET %s params=%s", url, params)
+            resp = self._session.get(url, params=params, timeout=self._timeout)
+            resp.raise_for_status()
+            data: Any = resp.json()
+
+            # Gamma returns either a plain list or {"markets": [...], "next_cursor": "..."}
+            if isinstance(data, list):
+                markets.extend(data)
+                break
+            else:
+                markets.extend(data.get("markets", []))
+                next_cursor: str = data.get("next_cursor", "") or ""
+                if not next_cursor:
+                    break
+                params = {"tag": "cs2", "active": "true", "next_cursor": next_cursor}
+
+        logger.info("Fetched %d CS2 markets", len(markets))
+        return markets
 
     # ---- CLOB API -----------------------------------------------------------
 

--- a/tests/test_polymarket_client.py
+++ b/tests/test_polymarket_client.py
@@ -106,6 +106,50 @@ class TestGetCs2Markets:
         # tenacity retries 3 times total (1 initial + 2 retries = 3 calls)
         assert mock_session.get.call_count == 3
 
+    def test_two_page_pagination(self) -> None:
+        """Two pages of results are accumulated into one flat list."""
+        client, mock_session = _make_client()
+        mock_session.get.side_effect = [
+            _make_response({"markets": [{"conditionId": "A"}], "next_cursor": "tok1"}),
+            _make_response({"markets": [{"conditionId": "B"}]}),
+        ]
+
+        result = client.get_cs2_markets()
+
+        assert len(result) == 2
+        assert result[0]["conditionId"] == "A"
+        assert result[1]["conditionId"] == "B"
+        # Second call must include next_cursor param
+        assert mock_session.get.call_count == 2
+        second_call_kwargs = mock_session.get.call_args_list[1][1]
+        assert second_call_kwargs.get("params", {}).get("next_cursor") == "tok1"
+
+    def test_three_page_pagination(self) -> None:
+        """Multiple pages are fully consumed until next_cursor is absent."""
+        client, mock_session = _make_client()
+        mock_session.get.side_effect = [
+            _make_response({"markets": [{"conditionId": "A"}], "next_cursor": "tok1"}),
+            _make_response({"markets": [{"conditionId": "B"}], "next_cursor": "tok2"}),
+            _make_response({"markets": [{"conditionId": "C"}]}),
+        ]
+
+        result = client.get_cs2_markets()
+
+        assert len(result) == 3
+        assert mock_session.get.call_count == 3
+
+    def test_empty_next_cursor_stops_pagination(self) -> None:
+        """An empty string next_cursor must stop pagination."""
+        client, mock_session = _make_client()
+        mock_session.get.return_value = _make_response(
+            {"markets": [{"conditionId": "A"}], "next_cursor": ""}
+        )
+
+        result = client.get_cs2_markets()
+
+        assert len(result) == 1
+        assert mock_session.get.call_count == 1
+
 
 # ---------------------------------------------------------------------------
 # get_market_prices


### PR DESCRIPTION
## Summary

Adds cursor-based pagination to `PolymarketClient.get_cs2_markets()` so all pages of CS2 markets are fetched, not just the first.

## Changes

- `src/clients/polymarket_client.py` — loop on `next_cursor` until exhausted; accumulate all pages; log at INFO level
- `tests/test_polymarket_client.py` — add `test_two_page_pagination`, `test_three_page_pagination`, `test_empty_next_cursor_stops_pagination`

## Closes

Closes #76