### PR TITLE
[ingestion] The Odds API: fetch CS2/esports bookmaker odds

### DIFF
--- a/app/clients/__init__.py
+++ b/app/clients/__init__.py
@@ -1,0 +1,1 @@
+# clients package

--- a/app/clients/odds_api_client.py
+++ b/app/clients/odds_api_client.py
@@ -1,0 +1,157 @@
+"""The Odds API client for fetching CS2/esports bookmaker odds."""
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+import structlog
+from cachetools import TTLCache
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+
+from app.config import settings
+
+logger = structlog.get_logger(__name__)
+
+_QUOTA_THRESHOLD = 10
+
+
+class QuotaExhaustedError(Exception):
+    """Raised when the Odds API quota drops below the safety threshold."""
+
+    def __init__(self, remaining: int) -> None:
+        super().__init__(f"Odds API quota critically low: {remaining} requests remaining")
+        self.remaining = remaining
+
+
+def _is_retryable(exc: BaseException) -> bool:
+    """Return True for 429 / 5xx HTTP errors — these warrant a retry."""
+    if isinstance(exc, requests.HTTPError):
+        status = exc.response.status_code if exc.response is not None else 0
+        return status == 429 or status >= 500
+    return False
+
+
+class OddsAPIClient:
+    """Client for The Odds API v4.
+
+    Args:
+        api_key: The Odds API key. Defaults to ``settings.odds_api_key``.
+        base_url: API base URL. Defaults to ``"https://api.the-odds-api.com/v4"``.
+        sport_key: Sport key to query. Defaults to ``"esports_cs2"``.
+        session: Optional pre-configured ``requests.Session`` (useful for testing).
+    """
+
+    def __init__(
+        self,
+        api_key: str = "",
+        base_url: str = "https://api.the-odds-api.com/v4",
+        sport_key: str = "esports_cs2",
+        session: requests.Session | None = None,
+    ) -> None:
+        self._api_key = api_key or settings.odds_api_key
+        self._base_url = base_url.rstrip("/")
+        self._sport_key = sport_key
+        self._session = session or requests.Session()
+        # Per-instance TTLCache so tests get isolated caches.
+        self._odds_cache: TTLCache[tuple[str, str, str], list[dict[str, Any]]] = TTLCache(
+            maxsize=16, ttl=300
+        )
+
+    # ---- Internal helpers --------------------------------------------------
+
+    def _fetch_cs2_odds(
+        self,
+        regions: str,
+        markets: str,
+        odds_format: str,
+    ) -> list[dict[str, Any]]:
+        """Perform the actual HTTP request for CS2 odds (no cache)."""
+        url = f"{self._base_url}/sports/{self._sport_key}/odds/"
+        params: dict[str, str] = {
+            "apiKey": self._api_key,
+            "regions": regions,
+            "markets": markets,
+            "oddsFormat": odds_format,
+        }
+        logger.debug("GET odds", url=url, regions=regions, markets=markets)
+        resp = self._session.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+
+        remaining_str = resp.headers.get("X-Requests-Remaining", "")
+        used_str = resp.headers.get("X-Requests-Used", "")
+        remaining: int = int(remaining_str) if remaining_str.isdigit() else 999
+
+        logger.info(
+            "odds_api_quota",
+            requests_remaining=remaining,
+            requests_used=used_str,
+        )
+
+        if remaining < _QUOTA_THRESHOLD:
+            raise QuotaExhaustedError(remaining)
+
+        data: Any = resp.json()
+        return data  # type: ignore[return-value]
+
+    # ---- Public API --------------------------------------------------------
+
+    @retry(
+        retry=retry_if_exception(_is_retryable),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=8),
+        reraise=True,
+    )
+    def get_cs2_odds(
+        self,
+        regions: str = "us,eu",
+        markets: str = "h2h",
+        odds_format: str = "decimal",
+    ) -> list[dict[str, Any]]:
+        """Fetch current CS2 odds from The Odds API.
+
+        Results are cached for 5 minutes per (regions, markets, odds_format) key
+        to preserve the monthly quota.
+
+        Args:
+            regions: Comma-separated region codes (e.g. ``"us,eu"``).
+            markets: Market type (e.g. ``"h2h"``).
+            odds_format: Odds format (``"decimal"`` or ``"american"``).
+
+        Returns:
+            List of raw event dicts with bookmaker odds.
+
+        Raises:
+            QuotaExhaustedError: When remaining quota drops below threshold.
+            requests.HTTPError: On non-2xx responses (4xx not retried).
+        """
+        cache_key = (regions, markets, odds_format)
+        if cache_key in self._odds_cache:
+            logger.debug("odds_api_cache_hit", key=cache_key)
+            return self._odds_cache[cache_key]
+
+        result = self._fetch_cs2_odds(regions, markets, odds_format)
+        self._odds_cache[cache_key] = result
+        return result
+
+    @retry(
+        retry=retry_if_exception(_is_retryable),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=8),
+        reraise=True,
+    )
+    def get_available_sports(self) -> list[str]:
+        """Return list of available sport keys from The Odds API.
+
+        Returns:
+            List of sport key strings (e.g. ``["esports_cs2", ...]``).
+
+        Raises:
+            requests.HTTPError: On non-2xx responses.
+        """
+        url = f"{self._base_url}/sports/"
+        params: dict[str, str] = {"apiKey": self._api_key}
+        logger.debug("GET sports", url=url)
+        resp = self._session.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        data: Any = resp.json()
+        return [item["key"] for item in data]

--- a/tests/test_odds_api_client.py
+++ b/tests/test_odds_api_client.py
@@ -1,0 +1,141 @@
+"""Unit tests for OddsAPIClient.
+
+All HTTP calls are mocked — no live network access required.
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from app.clients.odds_api_client import OddsAPIClient, QuotaExhaustedError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_response(
+    json_data: Any,
+    status_code: int = 200,
+    remaining: int = 450,
+    used: int = 50,
+) -> MagicMock:
+    """Build a mock requests.Response."""
+    mock_resp = MagicMock(spec=requests.Response)
+    mock_resp.status_code = status_code
+    mock_resp.json.return_value = json_data
+    mock_resp.headers = {
+        "X-Requests-Remaining": str(remaining),
+        "X-Requests-Used": str(used),
+    }
+    if status_code >= 400:
+        http_err = requests.HTTPError(response=mock_resp)
+        mock_resp.raise_for_status.side_effect = http_err
+    else:
+        mock_resp.raise_for_status.return_value = None
+    return mock_resp
+
+
+def _make_client() -> tuple[OddsAPIClient, MagicMock]:
+    """Return an OddsAPIClient with a mocked session."""
+    mock_session = MagicMock(spec=requests.Session)
+    client = OddsAPIClient(
+        api_key="test-key",
+        base_url="https://api.test",
+        session=mock_session,
+    )
+    return client, mock_session
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetCs2Odds:
+    def test_returns_list_of_events(self) -> None:
+        """Happy path: returns list of event dicts."""
+        events = [
+            {"id": "abc", "home_team": "NaVi", "away_team": "FaZe"},
+            {"id": "def", "home_team": "Liquid", "away_team": "ENCE"},
+        ]
+        client, mock_session = _make_client()
+        mock_session.get.return_value = _make_response(events)
+
+        result = client.get_cs2_odds()
+
+        assert result == events
+
+    def test_quota_logged(self) -> None:
+        """Successful call completes without error; quota headers consumed."""
+        client, mock_session = _make_client()
+        mock_session.get.return_value = _make_response([], remaining=300)
+
+        result = client.get_cs2_odds()
+
+        assert isinstance(result, list)
+        mock_session.get.assert_called_once()
+
+    def test_raises_quota_exhausted_when_below_threshold(self) -> None:
+        """X-Requests-Remaining below 10 raises QuotaExhaustedError."""
+        client, mock_session = _make_client()
+        mock_session.get.return_value = _make_response([], remaining=5)
+
+        with pytest.raises(QuotaExhaustedError) as exc_info:
+            client.get_cs2_odds()
+
+        assert exc_info.value.remaining == 5
+
+    def test_raises_http_error_on_4xx(self) -> None:
+        """4xx errors raise immediately without retry."""
+        client, mock_session = _make_client()
+        mock_session.get.return_value = _make_response({}, status_code=404)
+
+        with pytest.raises(requests.HTTPError):
+            client.get_cs2_odds()
+
+        # No retry on 4xx
+        assert mock_session.get.call_count == 1
+
+    def test_retries_on_5xx_then_raises(self) -> None:
+        """5xx errors are retried 3 times then raise."""
+        client, mock_session = _make_client()
+        mock_session.get.return_value = _make_response({}, status_code=500)
+
+        with pytest.raises(requests.HTTPError):
+            client.get_cs2_odds()
+
+        assert mock_session.get.call_count == 3
+
+    def test_cache_prevents_second_http_call(self) -> None:
+        """Second call within TTL returns cached result without HTTP request."""
+        client, mock_session = _make_client()
+        events = [{"id": "xyz"}]
+        mock_session.get.return_value = _make_response(events)
+
+        first = client.get_cs2_odds()
+        second = client.get_cs2_odds()
+
+        assert first == events
+        assert second == events
+        # Only one HTTP call made — second hit the cache
+        assert mock_session.get.call_count == 1
+
+
+class TestGetAvailableSports:
+    def test_get_available_sports_returns_keys(self) -> None:
+        """Returns list of sport key strings."""
+        client, mock_session = _make_client()
+        sports_data = [
+            {"key": "esports_cs2", "title": "CS2"},
+            {"key": "soccer_epl", "title": "Premier League"},
+        ]
+        mock_session.get.return_value = _make_response(sports_data)
+
+        result = client.get_available_sports()
+
+        assert result == ["esports_cs2", "soccer_epl"]


### PR DESCRIPTION
## Summary

Implements `OddsAPIClient` for fetching CS2/esports bookmaker odds from The Odds API.

## Changes

- `app/clients/__init__.py` — new clients package
- `app/clients/odds_api_client.py` — `OddsAPIClient` class with:
  - `get_cs2_odds()`: fetches odds, parses quota headers, raises `QuotaExhaustedError` when <10 remaining, tenacity retry on 429/5xx, 5-min per-instance TTL cache
  - `get_available_sports()`: returns list of sport key strings
  - `QuotaExhaustedError` custom exception
- `tests/test_odds_api_client.py` — 7 unit tests (all mocked, no live calls)

## Notes

- Cache is per-instance (`TTLCache` set in `__init__`) so tests remain isolated
- Follows patterns from `src/clients/polymarket_client.py`
- Imports settings from `app.config` (not legacy `config.py`)

Closes #54