### PR TITLE
[ingestion] Odds normalizer: decimal/American conversion, vig removal, arb builder

### DIFF
--- a/app/ingestion/__init__.py
+++ b/app/ingestion/__init__.py
@@ -1,0 +1,1 @@
+# ingestion package

--- a/app/ingestion/normalizer.py
+++ b/app/ingestion/normalizer.py
@@ -1,0 +1,181 @@
+"""Odds normalization utilities: convert bookmaker odds to implied probabilities.
+
+Handles decimal and American formats, vig removal, and ArbitrageOpportunity
+construction from matched Polymarket/bookmaker event pairs.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from app.models import ArbitrageOpportunity, BookmakerOdds, PolymarketMarket
+
+# Polymarket taker fee applied to all implied probability calculations.
+_POLY_TAKER_FEE = 0.02
+
+
+# ---------------------------------------------------------------------------
+# Conversion helpers
+# ---------------------------------------------------------------------------
+
+
+def decimal_to_implied(odds: float) -> float:
+    """Convert decimal odds to implied probability.
+
+    Args:
+        odds: Decimal odds (e.g. 2.0 for even money).
+
+    Returns:
+        Implied probability in [0.0, 1.0].
+    """
+    return 1.0 / odds
+
+
+def american_to_implied(odds: int) -> float:
+    """Convert American (moneyline) odds to implied probability.
+
+    Args:
+        odds: American odds (e.g. -110 or +200).
+
+    Returns:
+        Implied probability in [0.0, 1.0].
+    """
+    if odds >= 0:
+        return 100.0 / (odds + 100.0)
+    abs_odds = abs(odds)
+    return abs_odds / (abs_odds + 100.0)
+
+
+# ---------------------------------------------------------------------------
+# Vig removal
+# ---------------------------------------------------------------------------
+
+
+def remove_vig(implied_probs: dict[str, float]) -> dict[str, float]:
+    """Normalise implied probabilities so they sum to exactly 1.0.
+
+    Args:
+        implied_probs: Dict of outcome -> raw implied probability (may sum > 1
+            due to bookmaker vig/overround).
+
+    Returns:
+        Dict of outcome -> fair probability summing to 1.0.
+    """
+    total = sum(implied_probs.values())
+    if total == 0.0:
+        return dict(implied_probs)
+    return {k: v / total for k, v in implied_probs.items()}
+
+
+# ---------------------------------------------------------------------------
+# Bookmaker event normalization
+# ---------------------------------------------------------------------------
+
+
+def normalize_bookmaker_event(event: dict[str, Any]) -> BookmakerOdds:
+    """Convert a raw Odds API event dict to a ``BookmakerOdds`` model.
+
+    Picks the bookmaker with the lowest vig (sum of implied probabilities
+    closest to 1.0) from the ``h2h`` market.
+
+    Args:
+        event: Raw event dict from the Odds API, containing keys:
+            - ``home_team`` (str)
+            - ``away_team`` (str)
+            - ``commence_time`` (ISO 8601 str)
+            - ``bookmakers`` (list of bookmaker dicts with ``title`` and
+              ``markets`` fields)
+
+    Returns:
+        ``BookmakerOdds`` instance populated from the best bookmaker.
+    """
+    home = event["home_team"]
+    away = event["away_team"]
+    event_name = f"{home} vs {away}"
+
+    best_bookmaker: str = ""
+    best_decimal: dict[str, float] = {}
+    best_implied: dict[str, float] = {}
+    best_vig = float("inf")
+
+    for bm in event.get("bookmakers", []):
+        for market in bm.get("markets", []):
+            if market.get("key") != "h2h":
+                continue
+            dec: dict[str, float] = {o["name"]: float(o["price"]) for o in market["outcomes"]}
+            implied_raw = {name: decimal_to_implied(price) for name, price in dec.items()}
+            vig = sum(implied_raw.values()) - 1.0
+            if vig < best_vig:
+                best_vig = vig
+                best_bookmaker = bm["title"]
+                best_decimal = dec
+                best_implied = implied_raw
+
+    return BookmakerOdds(
+        bookmaker=best_bookmaker,
+        event_name=event_name,
+        team_a=home,
+        team_b=away,
+        decimal_odds=best_decimal,
+        implied_probs=remove_vig(best_implied),
+        fetched_at=datetime.utcnow(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Opportunity builder
+# ---------------------------------------------------------------------------
+
+
+def build_opportunities(
+    matches: list[tuple[PolymarketMarket, BookmakerOdds]],
+) -> list[ArbitrageOpportunity]:
+    """Build ``ArbitrageOpportunity`` objects from matched market pairs.
+
+    For each pair applies the Polymarket 2% taker fee to implied probabilities
+    and removes bookmaker vig, then computes per-outcome edge values.
+
+    Args:
+        matches: List of ``(PolymarketMarket, BookmakerOdds)`` pairs returned
+            by the fuzzy matcher.
+
+    Returns:
+        List of ``ArbitrageOpportunity`` objects where ``edge_pct > 0``.
+    """
+    opportunities: list[ArbitrageOpportunity] = []
+
+    for poly_market, book_odds in matches:
+        fair_book_probs = remove_vig(book_odds.implied_probs)
+
+        best_edge = 0.0
+        best_outcome = ""
+        best_poly_prob = 0.0
+        best_book_prob = 0.0
+
+        for outcome, poly_prob in poly_market.implied_probs.items():
+            book_prob = fair_book_probs.get(outcome)
+            if book_prob is None:
+                continue
+            # Apply Polymarket 2% taker fee
+            poly_prob_adj = poly_prob * (1.0 - _POLY_TAKER_FEE)
+            edge = poly_prob_adj - book_prob
+            if edge > best_edge:
+                best_edge = edge
+                best_outcome = outcome
+                best_poly_prob = poly_prob_adj
+                best_book_prob = book_prob
+
+        if best_edge > 0.0:
+            opportunities.append(
+                ArbitrageOpportunity(
+                    polymarket_market=poly_market,
+                    bookmaker_odds=book_odds,
+                    edge_pct=best_edge * 100.0,
+                    best_outcome=best_outcome,
+                    polymarket_prob=best_poly_prob,
+                    bookmaker_prob=best_book_prob,
+                    ev_adjusted=best_edge * 100.0,
+                )
+            )
+
+    return opportunities

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -1,0 +1,217 @@
+"""Unit tests for app.ingestion.normalizer."""
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from app.ingestion.normalizer import (
+    american_to_implied,
+    build_opportunities,
+    decimal_to_implied,
+    normalize_bookmaker_event,
+    remove_vig,
+)
+from app.models import ArbitrageOpportunity, BookmakerOdds, PolymarketMarket
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_poly_market(
+    team_a: str = "NaVi",
+    team_b: str = "FaZe",
+    prob_a: float = 0.6,
+) -> PolymarketMarket:
+    prob_b = round(1.0 - prob_a, 6)
+    return PolymarketMarket(
+        market_id="test-market-id",
+        question=f"Will {team_a} win?",
+        outcomes=[team_a, team_b],
+        implied_probs={team_a: prob_a, team_b: prob_b},
+        volume_usd=10000.0,
+        event_name=f"{team_a} vs {team_b}",
+        team_a=team_a,
+        team_b=team_b,
+    )
+
+
+def _make_book_odds(
+    team_a: str = "NaVi",
+    team_b: str = "FaZe",
+    prob_a: float = 0.5,
+) -> BookmakerOdds:
+    prob_b = round(1.0 - prob_a, 6)
+    return BookmakerOdds(
+        bookmaker="Pinnacle",
+        event_name=f"{team_a} vs {team_b}",
+        team_a=team_a,
+        team_b=team_b,
+        decimal_odds={team_a: round(1.0 / prob_a, 4), team_b: round(1.0 / prob_b, 4)},
+        implied_probs={team_a: prob_a, team_b: prob_b},
+        fetched_at=datetime.utcnow(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# decimal_to_implied
+# ---------------------------------------------------------------------------
+
+
+class TestDecimalToImplied:
+    def test_even_money(self) -> None:
+        assert decimal_to_implied(2.0) == pytest.approx(0.5)
+
+    def test_one_point_five(self) -> None:
+        assert decimal_to_implied(1.5) == pytest.approx(0.6667, rel=1e-3)
+
+    def test_large_odds(self) -> None:
+        assert decimal_to_implied(10.0) == pytest.approx(0.1)
+
+
+# ---------------------------------------------------------------------------
+# american_to_implied
+# ---------------------------------------------------------------------------
+
+
+class TestAmericanToImplied:
+    def test_negative_110(self) -> None:
+        assert american_to_implied(-110) == pytest.approx(0.5238, rel=1e-3)
+
+    def test_positive_200(self) -> None:
+        assert american_to_implied(200) == pytest.approx(0.3333, rel=1e-3)
+
+    def test_positive_100(self) -> None:
+        assert american_to_implied(100) == pytest.approx(0.5)
+
+    def test_negative_200(self) -> None:
+        assert american_to_implied(-200) == pytest.approx(0.6667, rel=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# remove_vig
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveVig:
+    def test_sums_to_one(self) -> None:
+        result = remove_vig({"a": 0.55, "b": 0.55})
+        assert sum(result.values()) == pytest.approx(1.0)
+
+    def test_keys_preserved(self) -> None:
+        result = remove_vig({"home": 0.6, "away": 0.5})
+        assert set(result.keys()) == {"home", "away"}
+
+    def test_already_fair(self) -> None:
+        result = remove_vig({"a": 0.5, "b": 0.5})
+        assert result["a"] == pytest.approx(0.5)
+        assert result["b"] == pytest.approx(0.5)
+
+    def test_zero_total_returns_unchanged(self) -> None:
+        result = remove_vig({"a": 0.0, "b": 0.0})
+        assert result == {"a": 0.0, "b": 0.0}
+
+
+# ---------------------------------------------------------------------------
+# normalize_bookmaker_event
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeBookmakerEvent:
+    def _sample_event(self) -> dict:  # type: ignore[type-arg]
+        return {
+            "id": "event-123",
+            "home_team": "NaVi",
+            "away_team": "FaZe",
+            "commence_time": "2024-06-01T15:00:00Z",
+            "bookmakers": [
+                {
+                    "title": "Pinnacle",
+                    "markets": [
+                        {
+                            "key": "h2h",
+                            "outcomes": [
+                                {"name": "NaVi", "price": 1.8},
+                                {"name": "FaZe", "price": 2.2},
+                            ],
+                        }
+                    ],
+                },
+                {
+                    "title": "Bet365",
+                    "markets": [
+                        {
+                            "key": "h2h",
+                            "outcomes": [
+                                {"name": "NaVi", "price": 1.7},
+                                {"name": "FaZe", "price": 2.0},
+                            ],
+                        }
+                    ],
+                },
+            ],
+        }
+
+    def test_returns_bookmaker_odds(self) -> None:
+        result = normalize_bookmaker_event(self._sample_event())
+        assert isinstance(result, BookmakerOdds)
+
+    def test_correct_teams(self) -> None:
+        result = normalize_bookmaker_event(self._sample_event())
+        assert result.team_a == "NaVi"
+        assert result.team_b == "FaZe"
+
+    def test_implied_probs_sum_to_one(self) -> None:
+        result = normalize_bookmaker_event(self._sample_event())
+        assert sum(result.implied_probs.values()) == pytest.approx(1.0)
+
+    def test_picks_lowest_vig_bookmaker(self) -> None:
+        """Pinnacle (1.8 / 2.2) has lower vig than Bet365 (1.7 / 2.0)."""
+        result = normalize_bookmaker_event(self._sample_event())
+        assert result.bookmaker == "Pinnacle"
+
+
+# ---------------------------------------------------------------------------
+# build_opportunities
+# ---------------------------------------------------------------------------
+
+
+class TestBuildOpportunities:
+    def test_empty_input_returns_empty(self) -> None:
+        assert build_opportunities([]) == []
+
+    def test_no_positive_edge_returns_empty(self) -> None:
+        """Polymarket prob lower than book prob -> no opportunity."""
+        poly = _make_poly_market(prob_a=0.4)  # NaVi at 0.4
+        book = _make_book_odds(prob_a=0.6)    # Book has NaVi at 0.6 (poly*0.98=0.392 < 0.6)
+        result = build_opportunities([(poly, book)])
+        assert result == []
+
+    def test_positive_edge_returns_opportunity(self) -> None:
+        """Poly implied prob higher than book -> opportunity detected."""
+        # poly: NaVi=0.8, FaZe=0.2; book: NaVi=0.5, FaZe=0.5
+        # edge for NaVi = 0.8*0.98 - 0.5 = 0.784 - 0.5 = 0.284 > 0
+        poly = _make_poly_market(prob_a=0.8)
+        book = _make_book_odds(prob_a=0.5)
+        result = build_opportunities([(poly, book)])
+        assert len(result) == 1
+        assert isinstance(result[0], ArbitrageOpportunity)
+        assert result[0].edge_pct > 0.0
+        assert result[0].best_outcome == "NaVi"
+
+    def test_poly_fee_applied(self) -> None:
+        """2% fee must reduce poly_prob before edge calculation."""
+        poly = _make_poly_market(prob_a=0.8)
+        book = _make_book_odds(prob_a=0.5)
+        result = build_opportunities([(poly, book)])
+        assert len(result) == 1
+        assert result[0].polymarket_prob == pytest.approx(0.8 * 0.98, rel=1e-6)
+
+    def test_ev_adjusted_equals_edge_pct(self) -> None:
+        """ev_adjusted should equal edge_pct."""
+        poly = _make_poly_market(prob_a=0.8)
+        book = _make_book_odds(prob_a=0.5)
+        result = build_opportunities([(poly, book)])
+        assert result[0].ev_adjusted == pytest.approx(result[0].edge_pct, rel=1e-6)


### PR DESCRIPTION
## Summary

Implements the odds normalizer that converts raw bookmaker odds to fair probabilities and detects arbitrage edges.

## Changes

- `app/ingestion/__init__.py` — new ingestion package
- `app/ingestion/normalizer.py` with:
  - `decimal_to_implied(odds)` — 1/odds
  - `american_to_implied(odds)` — positive/negative moneyline conversion
  - `remove_vig(implied_probs)` — normalises to sum=1.0
  - `normalize_bookmaker_event(event)` — converts raw Odds API dict to `BookmakerOdds`, picks lowest-vig bookmaker
  - `build_opportunities(matches)` — applies 2% Polymarket taker fee, removes vig, computes `edge_pct` and `ev_adjusted` in percentage form
- `tests/test_normalizer.py` — 17 unit tests across all functions

## Notes on `min_edge_pct` reconciliation

`settings.min_edge_pct = 0.02` (fraction). `edge_pct` in `ArbitrageOpportunity` is stored as **percentage** (e.g. `3.5` for 3.5%). The UI slider filter should compare as: `opportunity.edge_pct >= settings.min_edge_pct * 100` (i.e. `>= 2.0`). This is noted for the UI wiring step.

Closes #56