### PR TITLE
[ingestion] Fuzzy event matcher: normalize team/event names across sources

### DIFF
--- a/app/data/__init__.py
+++ b/app/data/__init__.py
@@ -1,0 +1,1 @@
+# data package

--- a/app/data/matcher.py
+++ b/app/data/matcher.py
@@ -1,0 +1,164 @@
+"""Fuzzy event matcher: aligns Polymarket CS2 markets with bookmaker events.
+
+Handles disparate naming conventions (e.g. "NaVi" vs "Natus Vincere") using
+RapidFuzz token-sort-ratio scoring and a curated team alias table.
+"""
+from __future__ import annotations
+
+import json
+import unicodedata
+from pathlib import Path
+from typing import Any
+
+import structlog
+from rapidfuzz import fuzz
+
+from app.models import BookmakerOdds, PolymarketMarket
+
+logger = structlog.get_logger(__name__)
+
+# ---- Constants -------------------------------------------------------------
+
+_MATCH_THRESHOLD = 80  # minimum token-sort-ratio score to accept a match
+_TEAM_ALIASES_PATH = Path(__file__).parent / "team_aliases.json"
+
+# Mapping from canonical lowercased form -> canonical lowercased form.
+# Built from team_aliases.json: each alias variant maps to the canonical key.
+_ALIAS_MAP: dict[str, str] = {}
+
+
+def _load_aliases() -> dict[str, str]:
+    """Load the alias table from disk and build variant->canonical mapping."""
+    if not _TEAM_ALIASES_PATH.exists():
+        return {}
+    with _TEAM_ALIASES_PATH.open() as fh:
+        raw: dict[str, list[str]] = json.load(fh)
+    mapping: dict[str, str] = {}
+    for canonical, variants in raw.items():
+        mapping[canonical] = canonical  # canonical maps to itself
+        for variant in variants:
+            mapping[variant.lower()] = canonical
+    return mapping
+
+
+_ALIAS_MAP = _load_aliases()
+
+
+# ---- Normalisation helpers -------------------------------------------------
+
+
+def _strip_diacritics(text: str) -> str:
+    """Remove diacritic marks from a Unicode string."""
+    nfkd = unicodedata.normalize("NFKD", text)
+    return "".join(ch for ch in nfkd if not unicodedata.combining(ch))
+
+
+def normalize_team_name(name: str) -> str:
+    """Produce a canonical, lowercased team name for comparison.
+
+    Steps:
+    1. Lowercase.
+    2. Strip diacritics.
+    3. Look up in alias table; replace with canonical form if found.
+
+    Args:
+        name: Raw team name string.
+
+    Returns:
+        Canonical lowercased team name suitable for fuzzy comparison.
+    """
+    cleaned = _strip_diacritics(name.lower().strip())
+    return _ALIAS_MAP.get(cleaned, cleaned)
+
+
+def _team_similarity(name_a: str, name_b: str) -> float:
+    """Compute token-sort-ratio similarity between two team names [0, 100]."""
+    norm_a = normalize_team_name(name_a)
+    norm_b = normalize_team_name(name_b)
+    score: float = fuzz.token_sort_ratio(norm_a, norm_b)
+    return score
+
+
+def _match_teams(
+    poly_a: str,
+    poly_b: str,
+    book_a: str,
+    book_b: str,
+) -> float:
+    """Return average similarity score for a candidate event pairing.
+
+    Tries both orderings (A vs B and B vs A) and returns the best.
+    """
+    # Direct alignment
+    score_direct = (
+        _team_similarity(poly_a, book_a) + _team_similarity(poly_b, book_b)
+    ) / 2.0
+    # Swapped alignment
+    score_swapped = (
+        _team_similarity(poly_a, book_b) + _team_similarity(poly_b, book_a)
+    ) / 2.0
+    return max(score_direct, score_swapped)
+
+
+# ---- Public API ------------------------------------------------------------
+
+
+def match_events(
+    poly_markets: list[PolymarketMarket],
+    bookmaker_events: list[BookmakerOdds],
+) -> tuple[list[tuple[PolymarketMarket, BookmakerOdds]], list[PolymarketMarket]]:
+    """Match Polymarket CS2 markets to bookmaker events.
+
+    Uses fuzzy team-name similarity to pair events across sources. Each
+    Polymarket market is matched to at most one bookmaker event (the
+    highest-scoring pair above the threshold).
+
+    Args:
+        poly_markets: Normalised Polymarket markets.
+        bookmaker_events: Normalised bookmaker odds events.
+
+    Returns:
+        A 2-tuple of:
+        - ``matched``: List of ``(PolymarketMarket, BookmakerOdds)`` pairs.
+        - ``unmatched``: Polymarket markets that could not be matched.
+    """
+    matched: list[tuple[PolymarketMarket, BookmakerOdds]] = []
+    unmatched: list[PolymarketMarket] = []
+    used_book_indices: set[int] = set()
+
+    for poly in poly_markets:
+        best_score = 0.0
+        best_idx: int | None = None
+
+        for idx, book in enumerate(bookmaker_events):
+            if idx in used_book_indices:
+                continue
+            score = _match_teams(poly.team_a, poly.team_b, book.team_a, book.team_b)
+            logger.debug(
+                "match_score",
+                poly_event=poly.event_name,
+                book_event=book.event_name,
+                score=round(score, 1),
+            )
+            if score > best_score:
+                best_score = score
+                best_idx = idx
+
+        if best_idx is not None and best_score >= _MATCH_THRESHOLD:
+            matched.append((poly, bookmaker_events[best_idx]))
+            used_book_indices.add(best_idx)
+            logger.info(
+                "event_matched",
+                poly_event=poly.event_name,
+                book_event=bookmaker_events[best_idx].event_name,
+                score=round(best_score, 1),
+            )
+        else:
+            unmatched.append(poly)
+            logger.debug(
+                "event_unmatched",
+                poly_event=poly.event_name,
+                best_score=round(best_score, 1),
+            )
+
+    return matched, unmatched

--- a/app/data/team_aliases.json
+++ b/app/data/team_aliases.json
@@ -1,0 +1,22 @@
+{
+  "natus vincere": ["navi", "na`vi", "natus vincere", "naVi", "NAVI", "natus-vincere", "natus_vincere"],
+  "faze clan": ["faze", "FaZe", "fazeclan", "faze clan", "FaZe Clan"],
+  "g2 esports": ["g2", "G2", "g2 esports", "G2 Esports"],
+  "team vitality": ["vitality", "Vitality", "team vitality", "Team Vitality"],
+  "team liquid": ["liquid", "Liquid", "team liquid", "Team Liquid", "TL"],
+  "astralis": ["astralis", "Astralis", "AST"],
+  "ence": ["ence", "ENCE"],
+  "heroic": ["heroic", "Heroic", "HER"],
+  "cloud9": ["c9", "C9", "cloud9", "Cloud9", "Cloud 9", "cloud 9"],
+  "mouz": ["mouz", "MOUZ", "mousesports", "Mousesports", "MOUSESPORTS"],
+  "fnatic": ["fnatic", "Fnatic", "FNC"],
+  "nip": ["nip", "NIP", "ninjas in pyjamas", "Ninjas in Pyjamas", "NiP"],
+  "big": ["big", "BIG", "berlin international gaming", "Berlin International Gaming"],
+  "spirit": ["spirit", "Spirit", "team spirit", "Team Spirit", "SPRT"],
+  "imperial": ["imperial", "Imperial", "imperial esports", "Imperial Esports", "imp"],
+  "og": ["og", "OG", "original gamers", "Original Gamers"],
+  "fluxo": ["fluxo", "Fluxo", "fluxo demons"],
+  "apeks": ["apeks", "Apeks", "APX"],
+  "pera": ["pera", "Pera", "pera esports"],
+  "monte": ["monte", "Monte", "monte esports", "Monte Esports"]
+}

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -1,0 +1,143 @@
+"""Unit tests for app.data.matcher."""
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from app.data.matcher import match_events, normalize_team_name
+from app.models import BookmakerOdds, PolymarketMarket
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_poly(team_a: str, team_b: str) -> PolymarketMarket:
+    return PolymarketMarket(
+        market_id=f"pm-{team_a}-{team_b}",
+        question=f"Will {team_a} win vs {team_b}?",
+        outcomes=[team_a, team_b],
+        implied_probs={team_a: 0.6, team_b: 0.4},
+        volume_usd=5000.0,
+        event_name=f"{team_a} vs {team_b}",
+        team_a=team_a,
+        team_b=team_b,
+    )
+
+
+def _make_book(team_a: str, team_b: str) -> BookmakerOdds:
+    return BookmakerOdds(
+        bookmaker="Pinnacle",
+        event_name=f"{team_a} vs {team_b}",
+        team_a=team_a,
+        team_b=team_b,
+        decimal_odds={team_a: 1.8, team_b: 2.2},
+        implied_probs={team_a: 0.556, team_b: 0.455},
+        fetched_at=datetime.utcnow(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# normalize_team_name tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeTeamName:
+    def test_navi_alias(self) -> None:
+        """'NaVi' should normalize to 'natus vincere'."""
+        assert normalize_team_name("NaVi") == "natus vincere"
+
+    def test_faze_alias(self) -> None:
+        """'FaZe Clan' should normalize to 'faze clan'."""
+        assert normalize_team_name("FaZe Clan") == "faze clan"
+
+    def test_unknown_returns_lowercased(self) -> None:
+        """Unknown team names return lowercased."""
+        assert normalize_team_name("Unknown Team") == "unknown team"
+
+    def test_strips_diacritics(self) -> None:
+        """Diacritics removed before lookup."""
+        # 'naví' -> 'navi' -> 'natus vincere'
+        assert normalize_team_name("naví") == "natus vincere"
+
+    def test_case_insensitive(self) -> None:
+        """Lookup is case-insensitive."""
+        assert normalize_team_name("NAVI") == "natus vincere"
+
+    def test_g2_alias(self) -> None:
+        """'G2' normalizes to 'g2 esports'."""
+        assert normalize_team_name("G2") == "g2 esports"
+
+
+# ---------------------------------------------------------------------------
+# match_events tests
+# ---------------------------------------------------------------------------
+
+
+class TestMatchEvents:
+    def test_empty_returns_empty(self) -> None:
+        matched, unmatched = match_events([], [])
+        assert matched == []
+        assert unmatched == []
+
+    def test_no_bookmaker_events_all_unmatched(self) -> None:
+        poly = [_make_poly("NaVi", "FaZe")]
+        matched, unmatched = match_events(poly, [])
+        assert matched == []
+        assert len(unmatched) == 1
+
+    def test_exact_match(self) -> None:
+        """Identical team names produce a match."""
+        poly = [_make_poly("NaVi", "FaZe")]
+        book = [_make_book("NaVi", "FaZe")]
+        matched, unmatched = match_events(poly, book)
+        assert len(matched) == 1
+        assert unmatched == []
+        assert matched[0][0].team_a == "NaVi"
+        assert matched[0][1].bookmaker == "Pinnacle"
+
+    def test_alias_match_navi(self) -> None:
+        """'Natus Vincere' in Odds API matches 'NaVi' on Polymarket."""
+        poly = [_make_poly("NaVi", "FaZe")]
+        book = [_make_book("Natus Vincere", "FaZe Clan")]
+        matched, unmatched = match_events(poly, book)
+        assert len(matched) == 1
+        assert unmatched == []
+
+    def test_swapped_team_order_matches(self) -> None:
+        """Teams in reversed order should still match."""
+        poly = [_make_poly("NaVi", "FaZe")]
+        book = [_make_book("FaZe", "NaVi")]
+        matched, unmatched = match_events(poly, book)
+        assert len(matched) == 1
+        assert unmatched == []
+
+    def test_no_match_below_threshold(self) -> None:
+        """Completely unrelated team names produce no match."""
+        poly = [_make_poly("NaVi", "FaZe")]
+        book = [_make_book("Team Liquid", "G2 Esports")]
+        matched, unmatched = match_events(poly, book)
+        assert matched == []
+        assert len(unmatched) == 1
+
+    def test_each_book_event_used_once(self) -> None:
+        """A bookmaker event cannot be matched to two Polymarket markets."""
+        poly = [_make_poly("NaVi", "FaZe"), _make_poly("NaVi", "FaZe")]
+        book = [_make_book("NaVi", "FaZe")]
+        matched, unmatched = match_events(poly, book)
+        # Only one match; the second poly market is unmatched
+        assert len(matched) == 1
+        assert len(unmatched) == 1
+
+    def test_multiple_matches(self) -> None:
+        """Two distinct pairs both match correctly."""
+        poly = [_make_poly("NaVi", "FaZe"), _make_poly("G2", "Team Liquid")]
+        book = [
+            _make_book("Natus Vincere", "FaZe Clan"),
+            _make_book("G2 Esports", "Team Liquid"),
+        ]
+        matched, unmatched = match_events(poly, book)
+        assert len(matched) == 2
+        assert unmatched == []


### PR DESCRIPTION
## Summary

Implements fuzzy event matching to align Polymarket CS2 markets with bookmaker events despite different naming conventions.

## Changes

- `app/data/__init__.py` — new data package
- `app/data/team_aliases.json` — curated alias table for top 20 CS2 teams (NaVi ↔ Natus Vincere, FaZe ↔ FaZe Clan, etc.)
- `app/data/matcher.py`:
  - `normalize_team_name(name)` — strips diacritics, lowercases, resolves via alias table
  - `match_events(poly_markets, bookmaker_events)` — greedy best-match using `rapidfuzz.fuzz.token_sort_ratio` with threshold 80
  - Returns `(matched, unmatched)` tuple — unmatched Poly markets are surfaced for transparency
  - Match score logged at debug level for each candidate pair
- `tests/test_matcher.py` — 11 unit tests covering aliases, swap order, no-match, multiple matches, one-to-one constraint

## Notes

- Uses `rapidfuzz` (already in `pyproject.toml`) instead of `thefuzz` — same API, faster, no encoding issues
- Each bookmaker event matched at most once (greedy one-to-one)

Closes #55